### PR TITLE
Fixes for Alerts SLO definition and viewing

### DIFF
--- a/nerdlets/shared/queries/alert-driven-slo/single-document.js
+++ b/nerdlets/shared/queries/alert-driven-slo/single-document.js
@@ -16,11 +16,18 @@ import { updateTimeRangeFromScope } from '../../helpers';
  */
 /** provides the where clause for the queries given the alerts array provided by the component properties */
 const _getAlertsWhereClause = function(_alerts) {
-  if (_alerts.length === 0) {
-    // eslint-disable-next-line no-console
-    console.warn('No alerts defined for an alert-driven SLO');
-    return '';
-  }
+
+  //validate the _alert array being passed
+  try {
+
+    if (_alerts[0].policy_name === null || _alerts[0].policy_name === undefined) {
+      throw "Invalid Alert";
+    } //if
+  }//try
+  catch{
+    console.warn('No alerts defined for an alert-driven SLO. Returning all alerts for comparison. This may be a result of an old version of SLO/R, please delete the SLO and try to recreate.', _alerts);
+    return 'timestamp > 0';
+  } //catch
 
   const alertNames = _alerts.map(a => a.policy_name);
   const alertsClause = `policy_name IN ('${alertNames.join("', '")}')`;
@@ -61,7 +68,6 @@ const _getAlertDrivenSLOData = async function(props) {
     timeRange
   });
 
-  // console.debug(props);
   const __NRQL_OPEN = _getOpenedAlertNRQL(alerts, __beginTS, __endTS);
   const __NRQL_CLOSED = _getClosedAlertNRQL(alerts, __beginTS, __endTS);
 

--- a/nerdlets/shared/services/slo-documents.js
+++ b/nerdlets/shared/services/slo-documents.js
@@ -89,7 +89,17 @@ export const validateSlo = function(document) {
     if (document.alerts.length === 0) {
       return false;
     }
-  }
+    //add validation to ensure we have the alerts object array
+    try {
+
+      if (document.alerts[0].policy_name === null || document.alerts[0].policy_name === undefined) {
+        return false;
+      }
+    }//try
+    catch {
+      return false;
+    } //catch
+  } //if (alert driven SLOs)
 
   return true;
 };

--- a/nr1.json
+++ b/nr1.json
@@ -1,0 +1,6 @@
+{
+  "schemaType": "NERDPACK",
+  "id": "4380103d-eb2f-4465-80df-98cd6dbe9597",
+  "displayName": "nr1-slo-r",
+  "description": "Nerdpack nr1-slo-r"
+}


### PR DESCRIPTION
Should fix issues 53, 61, and 63 -- does tighter validation of the Alerts[] that defines an Alert driven SLO. 