### PR TITLE
Fix: issues 78 and 63 - Overview speed and scope

### DIFF
--- a/nerdlets/slo-r-entity/index.js
+++ b/nerdlets/slo-r-entity/index.js
@@ -198,7 +198,7 @@ export default class SLOREntityNedlet extends React.Component {
       collection: 'nr1-csg-slo-r',
       entityGuid: document.entityGuid,
 
-      // TO DO - Remove document.name and document.slo_name after we've reached an initial release
+      // TODO - Remove document.name and document.slo_name after we've reached an initial release
       documentId: document.documentId || document.name || document.slo_name
     };
 
@@ -210,6 +210,8 @@ export default class SLOREntityNedlet extends React.Component {
     }
 
     this.removeDocumentFromList({ document });
+
+    // TODO: Check to see the entity in question has any other SLO documents in the collection and remove the tag slor=true if there are none. 
   }
 
   upsertDocumentInList({ mutationResult }) {

--- a/nerdlets/slo-r-main/components/slo-r-estate/index.js
+++ b/nerdlets/slo-r-main/components/slo-r-estate/index.js
@@ -32,7 +32,6 @@ import { SLO_INDICATORS } from '../../../shared/constants';
 export default class SLOREstate extends React.Component {
   static propTypes = {
     entities: PropTypes.array
-    // fetchMore: PropTypes.object
   }; // propTypes
 
   constructor(props) {
@@ -109,6 +108,8 @@ export default class SLOREstate extends React.Component {
         <BlockText>
           Unable to find any SLOs defined. Use the Entity Explorer to find a
           Service and define an SLO.
+
+          Barf Braf Brarf
         </BlockText>
       </StackItem>
     );

--- a/nerdlets/slo-r-main/components/slo-r-estate/index.js
+++ b/nerdlets/slo-r-main/components/slo-r-estate/index.js
@@ -10,8 +10,11 @@ import PropTypes from 'prop-types';
 /** nr1 */
 import {
   BlockText,
+  Button,
   Grid,
   GridItem,
+  HeadingText,
+  NerdGraphQuery,
   PlatformStateContext,
   Spinner,
   Stack,
@@ -108,8 +111,6 @@ export default class SLOREstate extends React.Component {
         <BlockText>
           Unable to find any SLOs defined. Use the Entity Explorer to find a
           Service and define an SLO.
-
-          Barf Braf Brarf
         </BlockText>
       </StackItem>
     );
@@ -145,6 +146,7 @@ export default class SLOREstate extends React.Component {
       </>
     );
   }
+
 
   render() {
     const {
@@ -204,6 +206,14 @@ export default class SLOREstate extends React.Component {
                   })}
                 </div>
               </StackItem>
+              <div className="header-right-side has-separator">
+              <StackItem>
+                <BlockText>
+                **Note: If you're not seeing an SLO Group in the drop-down box you need to ensure the slor=true tag hasn't been added to the entiies where you have defined SLOs.  
+                To add this tag simply open the SLO you have defined and re-save it through the entity explorer. Applies to SLO/R 1.5.1 and greater.
+                </BlockText>
+              </StackItem>
+              </div>
             </Stack>
           </StackItem>
         </Stack>

--- a/nerdlets/slo-r-main/index.js
+++ b/nerdlets/slo-r-main/index.js
@@ -72,7 +72,8 @@ export default class SloRMain extends React.Component {
     var __query;
     var __results;
 
-    /* loop until all the cursors have been exhaoused - 2400 records max */
+    /* loop until all the cursors have been exhaused - 2400 records max 
+       in general this shouldn't be an issue as we are scoping our slo lookup to those entities with the slor=true tag */
     while(__gotCursor) {
 
       __query = `{
@@ -91,20 +92,6 @@ export default class SloRMain extends React.Component {
         }
       }`;
 
-      /**
-       * {
-  actor {
-    entitySearch(queryBuilder: {tags: {key: "slor", value: "true"}, domain: APM, type: APPLICATION}) {
-      results {
-        entities {
-          guid
-          name
-        }
-      }
-    }
-  }
-}
-       */
       __results = await NerdGraphQuery.query({ query: __query, fetchPolicyType: NerdGraphQuery.FETCH_POLICY_TYPE.NO_CACHE });
 
       if (__results.data.actor.entitySearch.results !== null || __results.data.actor.entitySearch.results !== undefined) {
@@ -129,7 +116,7 @@ export default class SloRMain extends React.Component {
 
     return(__compositeResults);
 
-  } //_getCursorEntities
+  } // _getCursorEntities
 
   async componentWillMount() {
 

--- a/nerdlets/slo-r-main/index.js
+++ b/nerdlets/slo-r-main/index.js
@@ -8,9 +8,7 @@
 import React from 'react';
 
 /** nr1 */
-import { EntitiesByDomainTypeQuery, Spinner } from 'nr1';
-
-import { NerdGraphError } from '@newrelic/nr1-community';
+import { NerdGraphQuery, Spinner } from 'nr1';
 
 /** local */
 import SLOREstate from './components/slo-r-estate';
@@ -22,25 +20,137 @@ export default class SloRMain extends React.Component {
 
   constructor(props) {
     super(props);
+
+    this.state = {
+      entities: null
+    }
   } // constructor
 
+  async _getEntities() {
+
+    const __query = `{
+      actor {
+        entitySearch(queryBuilder: {tags: {key: "slor", value: "true"}, domain: APM, type: APPLICATION}) {
+          count
+          query
+          results {
+            entities {
+              guid
+              name
+            }
+            nextCursor
+          }
+        }
+      }
+    }`;
+
+    const __result = await NerdGraphQuery.query({ query: __query, fetchPolicyType: NerdGraphQuery.FETCH_POLICY_TYPE.NO_CACHE });
+   
+    //TODO Need NULL checks to verify the query retured with reasonable data
+    var __entities = __result.data.actor.entitySearch.results.entities;
+    var __moarEntities = [];
+
+    if (__result.data.actor.entitySearch.results.nextCursor !== null) {
+
+      __moarEntities = await this._getCursorEntities(__result.data.actor.entitySearch.results.nextCursor);
+    } // if
+
+    __entities = __entities.concat(__moarEntities);
+
+    this.setState({
+      entities: __entities
+    });
+
+    return(__entities);
+  } // _getEntities
+
+  async _getCursorEntities(_cursorId) {
+
+    var __gotCursor = true;
+    var __compositeResults = [];
+    var __cursorId = _cursorId;
+    var __query;
+    var __results;
+
+    /* loop until all the cursors have been exhaoused - 2400 records max */
+    while(__gotCursor) {
+
+      __query = `{
+        actor {
+          entitySearch(queryBuilder: {tags: {key: "slor", value: "true"}, domain: APM, type: APPLICATION}) {
+            count
+            query
+            results(cursor: "${__cursorId}") {
+              entities {
+                guid
+                name
+              }
+              nextCursor
+            }
+          }
+        }
+      }`;
+
+      /**
+       * {
+  actor {
+    entitySearch(queryBuilder: {tags: {key: "slor", value: "true"}, domain: APM, type: APPLICATION}) {
+      results {
+        entities {
+          guid
+          name
+        }
+      }
+    }
+  }
+}
+       */
+      __results = await NerdGraphQuery.query({ query: __query, fetchPolicyType: NerdGraphQuery.FETCH_POLICY_TYPE.NO_CACHE });
+
+      if (__results.data.actor.entitySearch.results !== null || __results.data.actor.entitySearch.results !== undefined) {
+
+        if (__results.data.actor.entitySearch.results.nextCursor !== null) {
+
+          __compositeResults = __compositeResults.concat(__results.data.actor.entitySearch.results.entities);
+          __cursorId = __results.data.actor.entitySearch.results.nextCursor;
+        } // if
+        else { 
+
+          __gotCursor = false;
+        } // else
+      } // if
+      else {
+
+        __gotCursor = false;
+      } // else
+
+
+    } // while
+
+    return(__compositeResults);
+
+  } //_getCursorEntities
+
+  async componentWillMount() {
+
+    if (this.state.entities === null) { 
+
+      await this._getEntities();
+    } // if
+    
+  } // componentWillMount
+
   render() {
-    return (
-      <div>
-        <EntitiesByDomainTypeQuery entityDomain="APM" entityType="APPLICATION">
-          {({ loading, error, data, fetchMore }) => {
-            if (loading) {
-              return <Spinner />;
-            }
-            if (error) {
-              return <NerdGraphError error={error} />;
-            }
-            return (
-              <SLOREstate entities={data.entities} fetchMore={fetchMore} />
-            );
-          }}
-        </EntitiesByDomainTypeQuery>
-      </div>
-    );
+
+    if (this.state.entities === null) {
+      return(<div>
+        <Spinner />
+      </div>);
+    } // if
+    else {
+      return(<div>
+        <SLOREstate entities={ this.state.entities } />
+      </div>);
+    } // else
   } // render
 } // SloRMain

--- a/nerdlets/slo-r-main/styles.scss
+++ b/nerdlets/slo-r-main/styles.scss
@@ -208,3 +208,16 @@ h2.no-slos-for-indicator-header {
   color: #8e9494;
   margin-top: -32px;
 }
+
+.header-right-side {
+  width: 600px;
+  margin-left:auto; margin-right:20px;
+  text-align: left;
+  vertical-align: middle;
+
+  [class*="wnd-Spacing"] {
+    font-size: 12px;
+    vertical-align: bottom;
+    margin-top: 1em;
+  }
+}


### PR DESCRIPTION
Provides ability to federate many more SLO entity instances - limit was top 200 alpha before - this should work up to 500 entities with SLOs. 

The upper limits of Entity search needs to be better addressed - will open a new enhancement request with those requirements. "Dealing with upper limits of Entity Search to federate SLOs".