### PR TITLE
removed the time range inherited from the time picker component in th…

### DIFF
--- a/nerdlets/slo-r-entity/components/slo-form.js
+++ b/nerdlets/slo-r-entity/components/slo-form.js
@@ -143,8 +143,6 @@ export default class SloForm extends React.Component {
     const { entityDetails, document } = this.state;
     const { timeRange } = this.props;
 
-    const timeRangeNrql = timeRangeToNrql(timeRange);
-
     if (entityDetails && document.alerts.length < 1) {
       const __query = `{
             actor {

--- a/nerdlets/slo-r-entity/components/slo-form.js
+++ b/nerdlets/slo-r-entity/components/slo-form.js
@@ -141,7 +141,6 @@ export default class SloForm extends React.Component {
 
   async _updateAlertConfig() {
     const { entityDetails, document } = this.state;
-    const { timeRange } = this.props;
 
     if (entityDetails && document.alerts.length < 1) {
       const __query = `{

--- a/nerdlets/slo-r-entity/components/slo-form.js
+++ b/nerdlets/slo-r-entity/components/slo-form.js
@@ -149,7 +149,7 @@ export default class SloForm extends React.Component {
       const __query = `{
             actor {
               account(id: ${entityDetails.accountId}) {
-                nrql(query: "SELECT count(*) FROM SLOR_ALERTS ${timeRangeNrql} FACET policy_name") {
+                nrql(query: "SELECT count(*) FROM SLOR_ALERTS SINCE 7 days ago FACET policy_name") {
                   results
                 }
               }

--- a/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
+++ b/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
@@ -100,8 +100,6 @@ export default class DefineSLOForm extends Component {
     const { entityDetails } = this.state;
     const { timeRange } = this.props;
 
-    const timeRangeNrql = timeRangeToNrql(timeRange);
-
     if (entityDetails) {
       const __query = `{
             actor {

--- a/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
+++ b/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
@@ -106,7 +106,7 @@ export default class DefineSLOForm extends Component {
       const __query = `{
             actor {
               account(id: ${entityDetails.accountId}) {
-                nrql(query: "SELECT count(*) FROM SLOR_ALERTS ${timeRangeNrql} FACET policy_name") {
+                nrql(query: "SELECT count(*) FROM SLOR_ALERTS SINCE 7 days ago FACET policy_name") {
                   results
                 }
               }

--- a/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
+++ b/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
@@ -98,7 +98,6 @@ export default class DefineSLOForm extends Component {
 
   fetchAlerts = async () => {
     const { entityDetails } = this.state;
-    const { timeRange } = this.props;
 
     if (entityDetails) {
       const __query = `{


### PR DESCRIPTION
…e SLOR_ALERTS query, in favour of hardcoding to a 7 day time range. This removes what is IMO confusing behaviour where the user needs to change the time picker to view the alerts events they may have in Insights, if an alert hasn't populated that event within the time period.|