### PR TITLE
feat: Add support for calculated latency SLOs

### DIFF
--- a/nerdlets/shared/constants.js
+++ b/nerdlets/shared/constants.js
@@ -2,7 +2,8 @@ export const SLO_INDICATORS = [
   { value: 'error_budget', label: 'Errors' },
   { value: 'availability', label: 'Availability' },
   { value: 'capacity', label: 'Capacity' },
-  { value: 'latency', label: 'Latency' }
+  { value: 'latency', label: 'Latency' },
+  { value: 'latency_budget', label: 'Latency (Calculated)' }
 ];
 
 export const ENTITY_COLLECTION_NAME = 'nr1-csg-slo-r';

--- a/nerdlets/shared/queries/error-budget-slo/composite.js
+++ b/nerdlets/shared/queries/error-budget-slo/composite.js
@@ -40,8 +40,9 @@ const _getErrorFilter = function(_transactions, _defects, language) {
         if (defect === 'apdex_frustrated') {
           __DEFECTS_FILTER = `${__DEFECTS_FILTER +
             __DEFECTS_JOIN}apdexPerfZone = 'F'`;
-        } // if
-        else {
+        } else if (defect.match(/duration > \.*\d+/)) {
+          __DEFECTS_FILTER = `${__DEFECTS_FILTER + __DEFECTS_JOIN}${defect}`;
+        } else {
           __DEFECTS_FILTER = `${__DEFECTS_FILTER +
             __DEFECTS_JOIN +
             _getAgentHTTPResponseAttributeName(language)} LIKE '${defect}'`;

--- a/nerdlets/shared/queries/error-budget-slo/single-document.js
+++ b/nerdlets/shared/queries/error-budget-slo/single-document.js
@@ -43,8 +43,10 @@ const _getErrorFilter = function(_transactions, _defects, language) {
         if (defect.value === 'apdex_frustrated') {
           __DEFECTS_FILTER = `${__DEFECTS_FILTER +
             __DEFECTS_JOIN}apdexPerfZone = 'F'`;
-        } // if
-        else {
+        } else if (defect.value.match(/duration > \.*\d+/)) {
+          __DEFECTS_FILTER = `${__DEFECTS_FILTER + __DEFECTS_JOIN}
+          ${defect.value}`;
+        } else {
           __DEFECTS_FILTER = `${__DEFECTS_FILTER +
             __DEFECTS_JOIN +
             _getAgentHTTPResponseAttributeName(language)} LIKE '${

--- a/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
+++ b/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
@@ -187,7 +187,14 @@ export default class DefineSLOForm extends Component {
               data={SLO_DEFECTS}
               className="defects-dropdown react-select-dropdown"
               placeholder="Select one or more defects"
-              onChange={value => setFieldValue('defects', value)}
+              onChange={e =>
+                setFieldValue('defects', [
+                  {
+                    value: `duration > ${e.target.value}`,
+                    label: `Duration > ${e.target.value}`
+                  }
+                ])
+              }
               defaultValue={values.defects}
             />
 

--- a/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
+++ b/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
@@ -249,7 +249,7 @@ export default class DefineSLOForm extends Component {
               validationText={errors.limit}
             />
 
-            <span className="multiselect__validation">{errors.defects}</span>
+            <span className="text-field__validation">{errors.defects}</span>
             <small className="input-description">
               Transactions with a duration greater than the limit will be
               counted against error budget attainment.

--- a/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
+++ b/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
@@ -288,7 +288,7 @@ export default class DefineSLOForm extends Component {
           will be able to edit this information in the future. Looking for
           guidance on{' '}
           <a
-            href="https://github.com/newrelic/nr1-slo-r/blob/master/docs/error_slos.md"
+            href="https://github.com/newrelic/nr1-slo-r/blob/main/docs/error_slos.md"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -296,7 +296,7 @@ export default class DefineSLOForm extends Component {
           </a>{' '}
           or{' '}
           <a
-            href="https://github.com/newrelic/nr1-slo-r/blob/master/docs/alert_slos.md"
+            href="https://github.com/newrelic/nr1-slo-r/blob/main/docs/alert_slos.md"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
+++ b/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
@@ -43,7 +43,7 @@ export default class DefineSLOForm extends Component {
     await this.getEntityInformation(entityGuid);
     const tags = await this.fetchEntityTags(entityGuid);
 
-    if (indicator === 'error_budget') {
+    if (indicator === 'error_budget' || indicator === 'latency_budget') {
       await this.fetchEntityTransactions();
     } else {
       await this.fetchAlerts();
@@ -119,7 +119,11 @@ export default class DefineSLOForm extends Component {
   };
 
   renderAlerts(values, setFieldValue, errors) {
-    if (!values.indicator || values.indicator === 'error_budget') {
+    if (
+      !values.indicator ||
+      values.indicator === 'error_budget' ||
+      values.indicator === 'latency_budget'
+    ) {
       return null;
     }
 
@@ -219,6 +223,56 @@ export default class DefineSLOForm extends Component {
     );
   }
 
+  renderLatencyBudget(values, setFieldValue, errors) {
+    if (values.indicator !== 'latency_budget') {
+      return null;
+    }
+
+    const { transactions } = this.state;
+
+    return (
+      <div>
+        <div className="latency-budget-dependency">
+          <div className="limit-field-container">
+            <h4 className="dropdown-label">Duration Limit</h4>
+            <TextField
+              onChange={e =>
+                setFieldValue('defects', [`duration > ${e.target.value}`])
+              }
+              validationText={errors.limit}
+            />
+
+            <span className="multiselect__validation">{errors.defects}</span>
+            <small className="input-description">
+              Transactions with a duration greater than the limit will be
+              counted against error budget attainment.
+            </small>
+          </div>
+        </div>
+
+        <div className="latency-budget-dependency">
+          <div className="transactions-dropdown-container">
+            <h4 className="dropdown-label">Transactions</h4>
+            <Multiselect
+              data={transactions.map(({ name }) => name)}
+              className="transactions-dropdown react-select-dropdown"
+              placeholder="Select one or more transactions"
+              onChange={value => setFieldValue('transactions', value)}
+              defaultValue={values.transactions}
+            />
+            <span className="multiselect__validation">
+              {errors.transactions}
+            </span>
+
+            <small className="input-description">
+              Select one or more transactions evaluate for this error budget.
+            </small>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   render() {
     const { slo, isEdit, isOpen, onClose, onSave, entities } = this.props;
     const { tags, isProcessing } = this.state;
@@ -234,7 +288,7 @@ export default class DefineSLOForm extends Component {
           will be able to edit this information in the future. Looking for
           guidance on{' '}
           <a
-            href="https://github.com/newrelic/nr1-slo-r/blob/main/docs/error_slos.md"
+            href="https://github.com/newrelic/nr1-slo-r/blob/master/docs/error_slos.md"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -242,7 +296,7 @@ export default class DefineSLOForm extends Component {
           </a>{' '}
           or{' '}
           <a
-            href="https://github.com/newrelic/nr1-slo-r/blob/main/docs/alert_slos.md"
+            href="https://github.com/newrelic/nr1-slo-r/blob/master/docs/alert_slos.md"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -377,7 +431,10 @@ export default class DefineSLOForm extends Component {
                       value={values.indicator}
                       onChange={async value => {
                         this.setState({ isProcessing: true });
-                        if (value === 'error_budget') {
+                        if (
+                          value === 'error_budget' ||
+                          value === 'latency_budget'
+                        ) {
                           await this.fetchEntityTransactions();
                         } else {
                           await this.fetchAlerts();
@@ -392,6 +449,7 @@ export default class DefineSLOForm extends Component {
                     </span>
                   </div>
                   {this.renderErrorBudget(values, setFieldValue, errors)}
+                  {this.renderLatencyBudget(values, setFieldValue, errors)}
                   {this.renderAlerts(values, setFieldValue, errors)}
                 </>
               )}

--- a/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
+++ b/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
@@ -338,21 +338,21 @@ export default class DefineSLOForm extends Component {
               .required('Target is required'),
             indicator: Yup.string().required('Indicator is required'),
             alerts: Yup.array().when('indicator', {
-              is: 'error_budget',
+              is: ('error_budget', 'latency_budget'),
               otherwise: Yup.array().min(
                 1,
                 'At least one alert must be selected'
               )
             }),
             transactions: Yup.array().when('indicator', {
-              is: 'error_budget',
+              is: ('error_budget', 'latency_budget'),
               then: Yup.array().min(
                 1,
                 'At least one transaction must be selected'
               )
             }),
             defects: Yup.array().when('indicator', {
-              is: 'error_budget',
+              is: ('error_budget', 'latency_budget'),
               then: Yup.array().min(1, 'At least one defect must be selected')
             })
           })}

--- a/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
+++ b/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
@@ -187,14 +187,7 @@ export default class DefineSLOForm extends Component {
               data={SLO_DEFECTS}
               className="defects-dropdown react-select-dropdown"
               placeholder="Select one or more defects"
-              onChange={e =>
-                setFieldValue('defects', [
-                  {
-                    value: `duration > ${e.target.value}`,
-                    label: `Duration > ${e.target.value}`
-                  }
-                ])
-              }
+              onChange={value => setFieldValue('defects', value)}
               defaultValue={values.defects}
             />
 
@@ -244,7 +237,12 @@ export default class DefineSLOForm extends Component {
             <h4 className="dropdown-label">Duration Limit</h4>
             <TextField
               onChange={e =>
-                setFieldValue('defects', [`duration > ${e.target.value}`])
+                setFieldValue('defects', [
+                  {
+                    value: `duration > ${e.target.value}`,
+                    label: `Duration > ${e.target.value}`
+                  }
+                ])
               }
               validationText={errors.limit}
             />

--- a/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
+++ b/nerdlets/slo-r-main/components/define-slo/define-slo-form.js
@@ -336,21 +336,21 @@ export default class DefineSLOForm extends Component {
               .required('Target is required'),
             indicator: Yup.string().required('Indicator is required'),
             alerts: Yup.array().when('indicator', {
-              is: ('error_budget', 'latency_budget'),
+              is: indicator => indicator.matches(/budget/) === true,
               otherwise: Yup.array().min(
                 1,
                 'At least one alert must be selected'
               )
             }),
             transactions: Yup.array().when('indicator', {
-              is: ('error_budget', 'latency_budget'),
+              is: indicator => indicator.matches(/budget/) === true,
               then: Yup.array().min(
                 1,
                 'At least one transaction must be selected'
               )
             }),
             defects: Yup.array().when('indicator', {
-              is: ('error_budget', 'latency_budget'),
+              is: indicator => indicator.matches(/budget/) === true,
               then: Yup.array().min(1, 'At least one defect must be selected')
             })
           })}

--- a/nerdlets/slo-r-main/components/slo-combine/table-summary.js
+++ b/nerdlets/slo-r-main/components/slo-combine/table-summary.js
@@ -49,7 +49,7 @@ export default class SummaryTable extends Component {
       const promises = [];
 
       const summaryFunction =
-        indicator === 'error_budget'
+        indicator === 'error_budget' || indicator === 'latency_budget'
           ? CompositeErrorBudgetSlo
           : CompositeAlertSlo;
 

--- a/nerdlets/slo-r-main/components/slo-list/main-view.js
+++ b/nerdlets/slo-r-main/components/slo-list/main-view.js
@@ -92,7 +92,10 @@ export default class MainView extends Component {
     const { document } = slo;
 
     const promises = scopes.map(scope => {
-      if (document.indicator === 'error_budget') {
+      if (
+        document.indicator === 'error_budget' ||
+        document.indicator === 'latency_budget'
+      ) {
         return ErrorBudgetSLO.query({
           scope,
           document,

--- a/nerdlets/slo-r-main/components/slo-list/view-document.js
+++ b/nerdlets/slo-r-main/components/slo-list/view-document.js
@@ -100,7 +100,10 @@ export default class ViewDocument extends React.Component {
     }
 
     const nrqlFunction =
-      document.indicator === 'error_budget' || document.type === 'error_budget'
+      document.indicator === 'error_budget' ||
+      document.type === 'error_budget' ||
+      document.indicator === 'latency_budget' ||
+      document.type === 'latency_budget'
         ? ErrorBudgetSLO
         : AlertDrivenSLO;
 

--- a/nerdlets/slo-r-main/components/slo-summary/index.js
+++ b/nerdlets/slo-r-main/components/slo-summary/index.js
@@ -82,7 +82,7 @@ export default class SloSummary extends React.Component {
     }
 
     const summaryFunction =
-      activeIndicator === 'error_budget'
+      activeIndicator === 'error_budget' || activeIndicator === 'latency_budget'
         ? CompositeErrorBudgetSlo
         : CompositeAlertSlo;
 


### PR DESCRIPTION
Adds support for calculating Latency SLOs like Error SLOs. Resolves #112 by adding a new option called "Calculated Latency" that appears as a separate indicator. Instead of defects, it accepts a maximum duration; any transactions above this limit are counted against the SLO.

To Do:
- [x] Implement feature
- [x] Test feature
- [x] Update documentation
- [x] Update semver and mark as ready for review