### PR TITLE
Fix: AlertDrivenSLO query was being used for latency_budget slos.  

### DIFF
--- a/nerdlets/slo-r-entity/components/slo-list.js
+++ b/nerdlets/slo-r-entity/components/slo-list.js
@@ -90,7 +90,10 @@ export default class SloList extends React.Component {
         const { document } = documentObject;
 
         scopes.forEach(scope => {
-          if (document.indicator === 'error_budget') {
+          if (
+            document.indicator === 'error_budget' ||
+            document.indicator === 'latency_budget'
+          ) {
             ErrorBudgetSLO.query({
               scope,
               document,


### PR DESCRIPTION
Fixed to use correct ErrorBudgetSLO query.